### PR TITLE
Feat/document context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -274,7 +274,13 @@
 					}
 				}
 			}
-		}
+		},
+		"commands": [
+			{
+				"command": "wingmanai.gendocument",
+				"title": "Gen Docs"
+			}
+		]
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",

--- a/src/commands/GenDocs.ts
+++ b/src/commands/GenDocs.ts
@@ -88,7 +88,6 @@ export class GenDocs implements vscode.CodeActionProvider {
             GenDocs.genCSharpDocs(editor, symbol, code);
           }
         }
-        vscode.window.showInformationMessage('The current line is the start of a method or class');
         return false;
       }
 

--- a/src/commands/GenDocs.ts
+++ b/src/commands/GenDocs.ts
@@ -1,0 +1,149 @@
+import vscode from 'vscode';
+import { eventEmitter } from "../events/eventEmitter";
+import { AIProvider, GetProviderFromSettings } from '../service/base';
+import { extractCsharpDocs, extractFromCodeMd, extractJsDocs, extractStringDocs } from '../service/extractFromCodeMd';
+import { generateDocPrompFactory } from '../service/generateDocPrompFactory';
+import { isTsRelated } from '../service/langCheckers';
+
+const isArrowFunction = (symbol: vscode.DocumentSymbol, document: vscode.TextDocument) => {
+  const isProperty = symbol.kind === vscode.SymbolKind.Property;
+  if (!isProperty) {
+    return false;
+  }
+
+  const line = document.lineAt(symbol.range.start.line).text;
+  return line.includes('=>');
+};
+
+export class GenDocs implements vscode.CodeActionProvider {
+  provideCodeActions(document: vscode.TextDocument, range: vscode.Selection | vscode.Range): vscode.ProviderResult<(vscode.CodeAction | vscode.Command)[]> {
+    // only provide code actions for the languages that we support
+    if (!isTsRelated(document.languageId) && document.languageId !== 'python' && document.languageId !== 'csharp') {
+      return;
+    }
+    const codeAction = new vscode.CodeAction('Document using wingman-ai', vscode.CodeActionKind.QuickFix);
+    codeAction.command = { command: GenDocs.command, title: 'Document using wingman-ai', arguments: [document, range] };
+    return [codeAction];
+  }
+
+  public static readonly command = 'wingmanai.gendocument';
+
+
+  static generateDocs() {
+    let editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      return;
+    }
+    const provider = GetProviderFromSettings();
+    const position = editor.selection.active; // Get the position of the cursor
+    vscode.window.withProgress({
+      location: vscode.ProgressLocation.Window,
+      title: 'Generating docs...'
+    }, async (process, token) => {
+      const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>('vscode.executeDocumentSymbolProvider', editor?.document.uri);
+      if (!symbols) {
+        return;
+      }
+
+      const abort = new AbortController();
+      if (editor) {
+        GenDocs.findMethod(symbols, editor, position, abort.signal, provider);
+      }
+
+    });
+  }
+
+  static async findMethod(symbols: vscode.DocumentSymbol[], editor: vscode.TextEditor, position: vscode.Position, signal: AbortSignal, provider: AIProvider): Promise<boolean> {
+    for (const symbol of symbols) {
+      if (signal.aborted) {
+        return false;
+      }
+      if (symbol.kind === vscode.SymbolKind.Class && symbol.range.contains(position)) {
+        GenDocs.findMethod(symbol.children, editor, position, signal, provider);
+        return false;
+      }
+      else if (
+        (symbol.kind === vscode.SymbolKind.Method ||
+          symbol.kind === vscode.SymbolKind.Function ||
+          isArrowFunction(symbol, editor.document)) && symbol.range.contains(position)
+      ) {
+        const text = editor.document.getText(symbol.range);
+
+        if (text && 'genCodeDocs' in provider) {
+          eventEmitter._onQueryStart.fire();
+          const result = await provider.genCodeDocs!(text, generateDocPrompFactory(editor.document.languageId), signal);
+          eventEmitter._onQueryComplete.fire();
+          let code = extractFromCodeMd(result);
+          if (!code) {
+            vscode.window.showErrorMessage('Failed to generate docs');
+            return false;
+          }
+          if (editor.document.languageId === 'python' && code.length) {
+            GenDocs.genPythonDocs(editor, symbol, code);
+          }
+          else if (isTsRelated(editor.document.languageId)) {
+            GenDocs.genJsDocs(editor, symbol, code);
+          }
+          else if (editor.document.languageId === 'csharp') {
+            GenDocs.genCSharpDocs(editor, symbol, code);
+          }
+        }
+        vscode.window.showInformationMessage('The current line is the start of a method or class');
+        return false;
+      }
+
+    }
+    return true;
+  }
+
+  static genPythonDocs(editor: vscode.TextEditor, symbol: vscode.DocumentSymbol, code: string) {
+    const text = editor.document.getText(symbol.range);
+    const signatureEnd = text.indexOf('\n');
+    const signatureEndPosition = symbol.range.start.translate(0, signatureEnd);
+    const firstLine = editor.document.lineAt(symbol.range.start.line).text;
+    const docs = extractStringDocs(code);
+    // get all the whitespaces for the first line
+    const spaceMatch = firstLine.match(/^\s*/gm);
+    if (spaceMatch?.length && docs.length) {
+      const leadingWhitespace = spaceMatch[0] + spaceMatch[0];
+      // Remove existing indentation from the comment
+      const unindentedDocs = docs.replace(/^\s+/gm, '');
+      // Prepend the leading whitespace to each line of the comment
+      const indentedDocs = unindentedDocs.split('\n').map(line => leadingWhitespace + line).join('\n');
+      editor.edit((editBuilder) => {
+        editBuilder.insert(signatureEndPosition, `\n${indentedDocs}`);
+      });
+    }
+  }
+
+  static genJsDocs(editor: vscode.TextEditor, symbol: vscode.DocumentSymbol, code: string) {
+    // get the space of the first line
+    const firstLine = editor.document.lineAt(symbol.range.start.line).text;
+    const spaceMatch = firstLine.match(/^\s*/gm);
+    const docs = extractJsDocs(code) + '\n';
+    if (spaceMatch?.length && docs.length) {
+      const leadingWhitespace = spaceMatch[0];
+      // need to remove all spaces and tabs from the start of the comment
+      const unindentedDocs = docs.replace(/^\s+/gm, '');
+      const indentedDocs = unindentedDocs.split('\n').map(line => leadingWhitespace + line).join('\n');
+      editor.edit((editBuilder) => {
+        editBuilder.insert(symbol.range.start, indentedDocs.trimStart());
+      });
+    }
+  }
+
+  static genCSharpDocs(editor: vscode.TextEditor, symbol: vscode.DocumentSymbol, code: string) {
+    const docs = extractCsharpDocs(code);
+    const firstLine = editor.document.lineAt(symbol.range.start.line).text;
+    const spaceMatch = firstLine.match(/^\s*/gm);
+    if (spaceMatch?.length && docs.length) {
+      const leading = spaceMatch[0];
+      const unindentedDocs = docs.replace(/^\s+/gm, '');
+      const indentedDocs = unindentedDocs.split('\n').map(line => leading + line).join('\n');
+      editor.edit((editBuilder) => {
+        editBuilder.insert(symbol.range.start, indentedDocs.trimStart() + '\n' + spaceMatch[0]);
+      });
+    }
+  }
+
+}

--- a/src/commands/GenDocs.ts
+++ b/src/commands/GenDocs.ts
@@ -21,6 +21,11 @@ export class GenDocs implements vscode.CodeActionProvider {
     if (!isTsRelated(document.languageId) && document.languageId !== 'python' && document.languageId !== 'csharp') {
       return;
     }
+    const provider = GetProviderFromSettings();
+    // if provider does not have 'genCodeDocs' in provider return
+    if (!('genCodeDocs' in provider)) {
+      return;
+    }
     const codeAction = new vscode.CodeAction('Document using wingman-ai', vscode.CodeActionKind.QuickFix);
     codeAction.command = { command: GenDocs.command, title: 'Document using wingman-ai', arguments: [document, range] };
     return [codeAction];

--- a/src/commands/GenDocs.ts
+++ b/src/commands/GenDocs.ts
@@ -26,8 +26,8 @@ export class GenDocs implements vscode.CodeActionProvider {
     if (!('genCodeDocs' in provider)) {
       return;
     }
-    const codeAction = new vscode.CodeAction('Document using wingman-ai', vscode.CodeActionKind.QuickFix);
-    codeAction.command = { command: GenDocs.command, title: 'Document using wingman-ai', arguments: [document, range] };
+    const codeAction = new vscode.CodeAction('✈️ Document using wingman-ai', vscode.CodeActionKind.QuickFix);
+    codeAction.command = { command: GenDocs.command, title: '✈️ Document using wingman-ai', arguments: [document, range] };
     return [codeAction];
   }
 

--- a/src/configview/HFSettingsView.tsx
+++ b/src/configview/HFSettingsView.tsx
@@ -26,10 +26,9 @@ export const HFSettingsView = ({ codeModel, chatModel, baseUrl, apiKey, onChange
       <VSCodeTextField onChange={handleChangeInput} value={baseUrl} data-name='baseUrl' title="HF base url">
         Base url:
       </VSCodeTextField>
-      <VSCodeTextField onChange={handleChangeInput} value={apiKey} data-name='apiPath' title="HF api key">
+      <VSCodeTextField onChange={handleChangeInput} value={apiKey} data-name='apiKey' title="HF api key">
         Api key:
       </VSCodeTextField>
     </Container>
   );
-
 }

--- a/src/configview/OpenAISettingsView.tsx
+++ b/src/configview/OpenAISettingsView.tsx
@@ -26,7 +26,7 @@ export const OpenAISettingsView = ({ codeModel, chatModel, baseUrl, apiKey, onCh
       <VSCodeTextField onChange={handleChangeInput} value={baseUrl} data-name='baseUrl' title="OpenAI base url">
         Base url:
       </VSCodeTextField>
-      <VSCodeTextField onChange={handleChangeInput} value={apiKey} data-name='apiPath' title="OpenAI api key">
+      <VSCodeTextField onChange={handleChangeInput} value={apiKey} data-name='apiKey' title="OpenAI api key">
         Api key:
       </VSCodeTextField>
     </Container>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,15 +1,16 @@
 import * as vscode from "vscode";
+import { GenDocs } from './commands/GenDocs.js';
 import { ChatViewProvider } from "./providers/chatViewProvider.js";
 import { CodeSuggestionProvider } from "./providers/codeSuggestionProvider.js";
 import { ConfigViewProvider } from "./providers/configViewProvider.js";
+import { QuickFixProvider } from "./providers/quickFixProvider.js";
+import { RefactorProvider } from "./providers/refactorProvider.js";
+import { ActivityStatusBar } from "./providers/statusBarProvider.js";
 import {
 	GetAllSettings,
 	GetInteractionSettings,
 	GetProviderFromSettings,
 } from "./service/base.js";
-import { ActivityStatusBar } from "./providers/statusBarProvider.js";
-import { QuickFixProvider } from "./providers/quickFixProvider.js";
-import { RefactorProvider } from "./providers/refactorProvider.js";
 
 let statusBarProvider: ActivityStatusBar;
 
@@ -27,6 +28,20 @@ export async function activate(context: vscode.ExtensionContext) {
 				vscode.commands.executeCommand("workbench.action.reloadWindow");
 			}
 		})
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			GenDocs.command,
+			GenDocs.generateDocs
+		)
+	);
+
+	context.subscriptions.push(
+		vscode.languages.registerCodeActionsProvider(
+			CodeSuggestionProvider.selector,
+			new GenDocs()
+		)
 	);
 
 	context.subscriptions.push(

--- a/src/providers/chatViewProvider.ts
+++ b/src/providers/chatViewProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
-import { AppMessage, CodeContext, CodeContextDetails } from "../types/Message";
-import { AIProvider } from "../service/base";
 import { eventEmitter } from "../events/eventEmitter";
+import { AIProvider } from "../service/base";
+import { AppMessage, CodeContext, CodeContextDetails } from "../types/Message";
 import { InteractionSettings } from "../types/Settings";
 
 let abortController = new AbortController();
@@ -15,7 +15,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
 		private readonly _aiProvider: AIProvider,
 		private readonly _context: vscode.ExtensionContext,
 		private readonly _interactionSettings: InteractionSettings
-	) {}
+	) { }
 
 	dispose() {
 		this._disposables.forEach((d) => d.dispose());
@@ -308,8 +308,6 @@ function getChatContext(contextWindow: number): CodeContextDetails | undefined {
 	if (text.length > contextWindow) {
 		text = text.substring(0, contextWindow);
 	}
-
-	console.log(text);
 
 	const documentUri = vscode.Uri.file(document.fileName);
 	const workspaceFolder = vscode.workspace.getWorkspaceFolder(documentUri);

--- a/src/providers/codeSuggestionProvider.ts
+++ b/src/providers/codeSuggestionProvider.ts
@@ -65,9 +65,12 @@ export class CodeSuggestionProvider implements InlineCompletionItemProvider {
 			}
 		});
 
-		const delayMs = this._interactionSettings.codeStreaming ? 150 : 300;
+		const delayMs = this._interactionSettings.codeStreaming ? 300 : 300;
 		try {
 			await delay(delayMs);
+			if (abort.signal.aborted) {
+				return [new InlineCompletionItem('')];
+			}
 			return await this.bouncedRequest(prefix, abort.signal, suffix, this._interactionSettings.codeStreaming);
 		}
 		catch {

--- a/src/service/base.ts
+++ b/src/service/base.ts
@@ -63,6 +63,9 @@ export interface AIProvider {
 		ragContent: string,
 		signal: AbortSignal
 	): AsyncGenerator<string>;
+	genCodeDocs?(prompt: string,
+		ragContent: string,
+		signal: AbortSignal): Promise<string>
 }
 
 export interface AIStreamProvicer extends AIProvider {

--- a/src/service/extractFromCodeMd.ts
+++ b/src/service/extractFromCodeMd.ts
@@ -1,0 +1,54 @@
+export const extractFromCodeMd = (text: string) => {
+  if (!text || !text.trim()) return '';
+  const regex = /```(\w*\n)?([\s\S]*?)```/;
+  const match = text.match(regex);
+
+  let codeBlockContent = '';
+  if (match) {
+    const startIndex = match.index! + match[0].indexOf(match[2]);
+    const endIndex = match.index! + match[0].lastIndexOf(match[2]) + match[2].length;
+    codeBlockContent = text.substring(startIndex, endIndex).trim();
+    return codeBlockContent;
+  }
+  else {
+    return '';
+  }
+};
+
+// fot a give python code, extract the string documentation
+export const extractStringDocs = (pythonCode: string) => {
+  // Should the reg ex use """ instead of "''"?
+  const regex = /"""([\s\S]*?)"""/;
+  const match = pythonCode.match(regex);
+  if (match) {
+    return `"""${match[1]}"""`;
+  }
+  else {
+    return '';
+  }
+};
+
+
+// for a given js / ts code, extract the jsdoc
+export const extractJsDocs = (jsCode: string) => {
+  const regex = /\/\*\*([\s\S]*?)\*\//;
+  const match = jsCode.match(regex);
+  if (match) {
+    return `/**${match[1]}*/`;
+  }
+  else {
+    return '';
+  }
+};
+
+export const extractCsharpDocs = (csharpCode: string) => {
+  // csharp doc comments use xml tags starting with /// <summary> and ending with /// </summary>
+  const regex = /\/\/\/\s?<summary>([\s\S]*?)\/\/\/\s?<\/summary>/;
+  const match = csharpCode.match(regex);
+  if (match) {
+    return match[0];
+  }
+  else {
+    return '';
+  }
+};

--- a/src/service/generateDocPrompFactory.ts
+++ b/src/service/generateDocPrompFactory.ts
@@ -1,0 +1,52 @@
+import { isTsRelated } from './langCheckers';
+
+/**
+    For example, for Python use the triple quotes.
+    For Javascript, Typescript and JSX and TSX use the JSDoc style.
+    For C# use the XML style.
+    For Java use the Javadoc style.
+    For Go use the godoc style.
+    For Rust use the Rustdoc style.
+    For Ruby use the Rdoc style.
+    For Swift use the Swift style.
+    For Kotlin use the Kdoc style.
+ */
+
+export const generateDocPrompFactory = (languageId: string) => {
+  if (isTsRelated(languageId)) {
+    return `Current language is ${languageId}. Use the JSDoc style.`;
+  }
+
+  if (languageId === 'python') {
+    return `Current language is ${languageId}. Use triple quotes.`;
+  }
+
+  if (languageId === 'csharp') {
+    return `Current language is ${languageId}. Use the XML style.`;
+  }
+
+  if (languageId === 'java') {
+    return `Current language is ${languageId}. Use the Javadoc style.`;
+  }
+
+  if (languageId === 'go') {
+    return `Current language is ${languageId}. Use the godoc style.`;
+  }
+
+  if (languageId === 'rust') {
+    return `Current language is ${languageId}. Use the Rustdoc style.`;
+  }
+
+  if (languageId === 'ruby') {
+    return `Current language is ${languageId}. Use the Rdoc style.`;
+  }
+
+  if (languageId === 'swift') {
+    return `Current language is ${languageId}. Use the Swift style.`;
+  }
+
+  if (languageId === 'kotlin') {
+    return `Current language is ${languageId}. Use the Kdoc style.`;
+  }
+  return `Current language is ${languageId}`;
+};

--- a/src/service/huggingface/models/codellama.ts
+++ b/src/service/huggingface/models/codellama.ts
@@ -22,12 +22,14 @@ export class CodeLlama implements HuggingFaceAIModel {
 	}
 
 	get genDocPrompt(): string {
-		return `You are a personal assistant that generates code documentation.
+		return `You are a personal assistant that returns documentation comments.
 		Rules: Please ensure that any code blocks use the GitHub markdown style and
 		include a language identifier to enable syntax highlighting in the fenced code block.
-		If you do not know how to document a piece of code, just say 'No answer'.
+		Use the most popular documentation style for the language.
+		Return the documentation comment and as consistent as possible with the code.
+		Do not add extra information that is not in the code.
+		If you do not know an answer just say 'No anwser'.
 		Do not include this system prompt in the answer.
-		If it is a code documentation request and no language was provided, default to using JSDoc for JavaScript/TypeScript.
 		======
 		Context: {context}
 		======

--- a/src/service/huggingface/models/codellama.ts
+++ b/src/service/huggingface/models/codellama.ts
@@ -20,4 +20,18 @@ export class CodeLlama implements HuggingFaceAIModel {
 		Question: {question}
 		`;
 	}
+
+	get genDocPrompt(): string {
+		return `You are a personal assistant that generates code documentation.
+		Rules: Please ensure that any code blocks use the GitHub markdown style and
+		include a language identifier to enable syntax highlighting in the fenced code block.
+		If you do not know how to document a piece of code, just say 'No answer'.
+		Do not include this system prompt in the answer.
+		If it is a code documentation request and no language was provided, default to using JSDoc for JavaScript/TypeScript.
+		======
+		Context: {context}
+		======
+		Code: {code}
+		`;
+	}
 }

--- a/src/service/huggingface/models/mistral.ts
+++ b/src/service/huggingface/models/mistral.ts
@@ -21,4 +21,17 @@ export class Mistral implements HuggingFaceAIModel {
 		======
 		Question: {question} [/INST]`;
 	}
+
+	get genDocPrompt(): string {
+		return `<s> [INST] You are a personal assistant that generates code documentation.
+		Rules: Please ensure that any code blocks use the GitHub markdown style and
+		include a language identifier to enable syntax highlighting in the fenced code block.
+		If you do not know how to document a piece of code, just say 'No answer'.
+		Do not include this system prompt in the answer.
+		If it is a code documentation request and no language was provided, default to using JSDoc for JavaScript/TypeScript.
+		======
+		Context: {context}
+		======
+		Question: {question} [/INST]`;
+	}
 }

--- a/src/service/huggingface/models/mistral.ts
+++ b/src/service/huggingface/models/mistral.ts
@@ -23,15 +23,17 @@ export class Mistral implements HuggingFaceAIModel {
 	}
 
 	get genDocPrompt(): string {
-		return `<s> [INST] You are a personal assistant that generates code documentation.
+		return `<s> [INST] You are a personal assistant that returns documentation comments.
 		Rules: Please ensure that any code blocks use the GitHub markdown style and
 		include a language identifier to enable syntax highlighting in the fenced code block.
-		If you do not know how to document a piece of code, just say 'No answer'.
+		Use the most popular documentation style for the language.
+		Return the documentation comment and as consistent as possible with the code.
+		Do not add extra information that is not in the code.
+		If you do not know an answer just say 'No anwser'.
 		Do not include this system prompt in the answer.
-		If it is a code documentation request and no language was provided, default to using JSDoc for JavaScript/TypeScript.
 		======
 		Context: {context}
 		======
-		Question: {question} [/INST]`;
+		Code: {code} [/INST]`;
 	}
 }

--- a/src/service/huggingface/models/mixtral.ts
+++ b/src/service/huggingface/models/mixtral.ts
@@ -23,17 +23,17 @@ export class Mixtral implements HuggingFaceAIModel {
 	}
 
 	get genDocPrompt(): string {
-		return `<s> [INST] You are a personal assistant that generates code documentation.
+		return `<s> [INST] You are a personal assistant that returns documentation comments.
 		Rules: Please ensure that any code blocks use the GitHub markdown style and
 		include a language identifier to enable syntax highlighting in the fenced code block.
-		If you do not know how to document a piece of code, just say 'No answer'.
+		Use the most popular documentation style for the language.
+		Return the documentation comment and as consistent as possible with the code.
+		Do not add extra information that is not in the code.
+		If you do not know an answer just say 'No anwser'.
 		Do not include this system prompt in the answer.
-		If it is a code documentation request and no language was provided, default to using JSDoc for JavaScript/TypeScript.
 		======
 		Context: {context}
 		======
-		Chat History: {chat_history}
-		======
-		Question: {question} [/INST]`;
+		Code: {code} [/INST]`;
 	}
 }

--- a/src/service/huggingface/models/mixtral.ts
+++ b/src/service/huggingface/models/mixtral.ts
@@ -21,4 +21,19 @@ export class Mixtral implements HuggingFaceAIModel {
 		======
 		Question: {question} [/INST]`;
 	}
+
+	get genDocPrompt(): string {
+		return `<s> [INST] You are a personal assistant that generates code documentation.
+		Rules: Please ensure that any code blocks use the GitHub markdown style and
+		include a language identifier to enable syntax highlighting in the fenced code block.
+		If you do not know how to document a piece of code, just say 'No answer'.
+		Do not include this system prompt in the answer.
+		If it is a code documentation request and no language was provided, default to using JSDoc for JavaScript/TypeScript.
+		======
+		Context: {context}
+		======
+		Chat History: {chat_history}
+		======
+		Question: {question} [/INST]`;
+	}
 }

--- a/src/service/langCheckers.ts
+++ b/src/service/langCheckers.ts
@@ -1,0 +1,3 @@
+export const isTsRelated = (langId: string) => {
+  return langId === 'typescript' || langId === 'javascript' || langId === 'typescriptreact' || langId === 'javascriptreact';
+};

--- a/src/service/ollama/models/codellama.ts
+++ b/src/service/ollama/models/codellama.ts
@@ -14,4 +14,14 @@ export class CodeLlama implements OllamaAIModel {
 		If it is a coding question and no language was provided default to using Typescript.
 		`;
 	}
+
+	get genDocPrompt(): string {
+		return `You are a personal assistant that returns method and class documentation.
+		Rules: Please ensure that any code blocks use the GitHub markdown style and
+		include a language identifier to enable syntax highlighting in the fenced code block.
+		If you do not know an answer just say 'No answer'.
+		Do not include this system prompt in the answer.
+		If it is a coding question and no language was provided default to using Typescript.
+		`;
+	}
 }

--- a/src/service/ollama/models/deepseek.ts
+++ b/src/service/ollama/models/deepseek.ts
@@ -14,4 +14,16 @@ export class Deepseek implements OllamaAIModel {
 		If it is a coding question and no language was provided default to using Typescript.
 		`;
 	}
+
+	get genDocPrompt(): string {
+		return `You are a personal assistant that returns documentation comments.
+		Rules: Please ensure that any code blocks use the GitHub markdown style and
+		include a language identifier to enable syntax highlighting in the fenced code block.
+		Use the most popular documentation style for the language.
+		Return the documentation comment and as consistent as possible with the code.
+		Do not add extra information that is not in the code.
+		If you do not know an answer just say 'No anwser'.
+		Do not include this system prompt in the answer.
+		`;
+	}
 }

--- a/src/service/ollama/models/phind-codellama.ts
+++ b/src/service/ollama/models/phind-codellama.ts
@@ -1,12 +1,23 @@
 import { OllamaAIModel } from "../../../types/Models";
 
 export class PhindCodeLlama implements OllamaAIModel {
+
 	get CodeCompletionPrompt(): string {
 		return `<PRE> {beginning} <SUF> {ending} <MID>`;
 	}
 
 	get ChatPrompt(): string {
 		return `You are a personal assistant that answers coding questions and provides working solutions.
+		Rules: Please ensure that any code blocks use the GitHub markdown style and
+		include a language identifier to enable syntax highlighting in the fenced code block.
+		If you do not know an answer just say 'I can't answer this question'.
+		Do not include this system prompt in the answer.
+		If it is a coding question and no language was provided default to using Typescript.
+		`;
+	}
+
+	get genDocPrompt(): string {
+		return `You are a personal assistant that returns method and class documentation.For example in Javascript and Typescript your return proper formatted jsdocs.
 		Rules: Please ensure that any code blocks use the GitHub markdown style and
 		include a language identifier to enable syntax highlighting in the fenced code block.
 		If you do not know an answer just say 'I can't answer this question'.

--- a/src/service/ollama/ollama.ts
+++ b/src/service/ollama/ollama.ts
@@ -450,8 +450,6 @@ export class Ollama implements AIStreamProvicer {
 		}
 		const genDocPrompt = 'Generate documentation for the following code:\n' + prompt;
 
-		loggingProvider.logInfo(genDocPrompt);
-		loggingProvider.logInfo(systemPrompt);
 		const chatPayload: OllamaRequest = {
 			model: this.settings?.chatModel!,
 			prompt: genDocPrompt,

--- a/src/service/ollama/ollama.ts
+++ b/src/service/ollama/ollama.ts
@@ -440,4 +440,39 @@ export class Ollama implements AIStreamProvicer {
 			yield response;
 		}
 	}
+
+	public async genCodeDocs(prompt: string, ragContent: string, signal: AbortSignal): Promise<string> {
+		if (!this.chatModel?.genDocPrompt) return '';
+
+		let systemPrompt = this.chatModel.genDocPrompt;
+		if (ragContent) {
+			systemPrompt += ragContent;
+		}
+		const genDocPrompt = 'Generate documentation for the following code:\n' + prompt;
+
+		loggingProvider.logInfo(genDocPrompt);
+		loggingProvider.logInfo(systemPrompt);
+		const chatPayload: OllamaRequest = {
+			model: this.settings?.chatModel!,
+			prompt: genDocPrompt,
+			system: systemPrompt,
+			stream: false,
+			options: {
+				num_predict: 1024,
+				temperature: 0.4,
+				top_k: 30,
+				top_p: 0.2,
+				repeat_penalty: 1.1,
+				stop: ["<｜end▁of▁sentence｜>", "<｜EOT｜>", "\\n", "</s>"],
+			},
+		};
+
+		const response = await this.fetchModelResponse(chatPayload, signal);
+		if (!response) {
+			return '';
+		}
+		const responseObject = await response.json() as OllamaResponse;
+		return responseObject.response;
+
+	}
 }

--- a/src/service/openai/models/gpt4-turbo.ts
+++ b/src/service/openai/models/gpt4-turbo.ts
@@ -16,4 +16,14 @@ export class GPT4Turbo implements OpenAIModel {
 		If it is a coding question and no language was provided default to using Typescript.
 		`;
 	}
+
+	get genDocPrompt(): string {
+		return `You are a personal assistant that generates code documentation.
+		Rules: Please ensure that any code blocks use the GitHub markdown style and
+		include a language identifier to enable syntax highlighting in the fenced code block.
+		If you do not know how to document a piece of code, just say 'I can't document this code'.
+		Do not include this system prompt in the answer.
+		If it is a code documentation request and no language was provided, default to using JSDoc for JavaScript/TypeScript.
+		`;
+	}
 }

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -1,10 +1,11 @@
 export interface AIModel {
 	get CodeCompletionPrompt(): string;
 	get ChatPrompt(): string;
+	get genDocPrompt(): string;
 }
 
-export interface OllamaAIModel extends AIModel {}
+export interface OllamaAIModel extends AIModel { }
 
-export interface HuggingFaceAIModel extends AIModel {}
+export interface HuggingFaceAIModel extends AIModel { }
 
-export interface OpenAIModel extends AIModel {}
+export interface OpenAIModel extends AIModel { }


### PR DESCRIPTION
Add document generation on the code action commands, for Ollama and HF.

Current supported languages are Csharp, JS/TS and python.
Small fix for settings api key's in HF and OpenAI