### PR TITLE
feat: add light theme support on chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "wing-man",
 	"displayName": "Wingman-AI",
 	"description": "Wingman - AI powered assistant to help you write your best code, we won't leave you hanging.",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"publisher": "WingMan",
 	"license": "MIT",
 	"authors": [

--- a/src/providers/chatViewProvider.ts
+++ b/src/providers/chatViewProvider.ts
@@ -3,6 +3,7 @@ import { eventEmitter } from "../events/eventEmitter";
 import { AIProvider } from "../service/base";
 import { AppMessage, CodeContext, CodeContextDetails } from "../types/Message";
 import { InteractionSettings } from "../types/Settings";
+import { loggingProvider } from './loggingProvider';
 import { getSymbolsFromOpenFiles } from "./utilities";
 
 let abortController = new AbortController();
@@ -16,7 +17,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
 		private readonly _aiProvider: AIProvider,
 		private readonly _context: vscode.ExtensionContext,
 		private readonly _interactionSettings: InteractionSettings
-	) {}
+	) { }
 
 	dispose() {
 		this._disposables.forEach((d) => d.dispose());
@@ -97,11 +98,19 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
 							command: "init",
 							value: {
 								workspaceFolder: getActiveWorkspace(),
+								theme: vscode.window.activeColorTheme.kind
 							},
 						});
 						break;
 					}
+					case "log": {
+						this.log(value);
+						break;
+					}
 				}
+			}),
+			vscode.window.onDidChangeActiveColorTheme((theme: vscode.ColorTheme) => {
+				webviewView.webview.postMessage({ command: 'setTheme', value: theme.kind });
 			})
 		);
 	}
@@ -236,6 +245,11 @@ ${currentLine}
           </body>
         </html>`;
 	}
+
+
+	private log = (value: unknown) => {
+		loggingProvider.logInfo(JSON.stringify(value ?? ""));
+	};
 }
 
 function getActiveWorkspace() {

--- a/src/webview-ui/App.tsx
+++ b/src/webview-ui/App.tsx
@@ -1,11 +1,12 @@
-import { vscode } from "./utilities/vscode";
 import { useEffect, useState } from "react";
+import { VscClearAll } from "react-icons/vsc";
+import styled from "styled-components";
 import { AppMessage, ChatMessage, CodeContext } from "../types/Message";
 import ChatEntry from "./ChatEntry";
-import styled from "styled-components";
-import { VscClearAll } from "react-icons/vsc";
-import { ChatResponseList } from "./ChatList";
 import { ChatInput } from "./ChatInput";
+import { ChatResponseList } from "./ChatList";
+import { localMemState } from './utilities/localMemState';
+import { vscode } from "./utilities/vscode";
 
 const Main = styled.main`
 	height: 100%;
@@ -108,9 +109,11 @@ const App = () => {
 				});
 				break;
 			case "init":
-				const { workspaceFolder } = value as {
+				const { workspaceFolder, theme } = value as {
 					workspaceFolder: string;
+					theme: number;
 				};
+				localMemState.setState('theme', theme);
 
 				activeWorkspace = workspaceFolder;
 
@@ -126,6 +129,9 @@ const App = () => {
 					setMessages(chatHistory[activeWorkspace]);
 				}
 				break;
+			case "setTheme":
+				const newTheme = value as number;
+				localMemState.setState('theme', newTheme);
 		}
 	};
 

--- a/src/webview-ui/ChatEntry.tsx
+++ b/src/webview-ui/ChatEntry.tsx
@@ -1,11 +1,12 @@
-import { PropsWithChildren, memo, useState } from "react";
-import Markdown from "react-markdown";
-import styled, { keyframes } from "styled-components";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
-import { ChatMessage } from "../types/Message";
+import { PropsWithChildren, memo, useState, useSyncExternalStore } from "react";
 import { FaCopy } from "react-icons/fa6";
 import { GoFileSymlinkFile } from "react-icons/go";
+import Markdown from "react-markdown";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { prism, vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
+import styled, { keyframes } from "styled-components";
+import { ChatMessage } from "../types/Message";
+import { localMemState } from './utilities/localMemState';
 import { vscode } from "./utilities/vscode";
 
 const Entry = styled.li`
@@ -205,6 +206,10 @@ const ChatEntry = ({
 		});
 	};
 
+	const lm = useSyncExternalStore(localMemState.subscribe, localMemState.getSnapshot);
+	const theme = lm['theme'] as number;
+	const codeTheme = (theme === 1 || theme === 4) ? prism : vscDarkPlus;
+
 	return (
 		<Entry>
 			<LabelContainer>
@@ -245,7 +250,7 @@ const ChatEntry = ({
 							<SyntaxHighlighter
 								PreTag={CodeContainer}
 								children={String(children).replace(/\n$/, "")}
-								style={vscDarkPlus}
+								style={codeTheme}
 								language={languageType[1]}
 							/>
 						) : (

--- a/src/webview-ui/utilities/localMemState.ts
+++ b/src/webview-ui/utilities/localMemState.ts
@@ -1,0 +1,24 @@
+class LocalMemState {
+  state: Record<string, unknown> = {};
+  listeners: Set<() => void> = new Set();
+
+  getState = (key: string) => this.state[key];
+
+  setState = (key: string, payload: unknown) => {
+    this.state[key] = payload;
+    this.listeners.forEach(l => l());
+  };
+
+  subscribe = (func: () => void) => {
+    this.listeners.add(func);
+    return () => {
+      this.listeners.delete(func);
+    };
+  };
+
+  getSnapshot = () => {
+    return { ...this.state };
+  };
+}
+
+export const localMemState = new LocalMemState();


### PR DESCRIPTION
On light theme the chat input is barely visible.
## Update
Add theme listener to change the markdown theme to match vscode color theme.

## Testing
1. Debug app
2. Open wingmain ai chat and ask it to write a simple loop.
3. Change the theme
4. Ask it to write something else

resolves #37 