### PR TITLE
fix: add savedState to prevent re-rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Supported Models for _Code Completion_:
 -   Deepseek-base _(tested with: [deepseek-coder:6.7b-base-q8_0](https://ollama.ai/library/deepseek-coder:6.7b-base-q8_0))_
 -   Codellama-code _(tested with: [codellama:7b-code-q4_K_M](https://ollama.ai/library/codellama:7b-code-q4_K_M))_
 -   Magicoder-DS _(tested with [wojtek/magicoder:6.7b-s-ds-q8_0](https://ollama.com/wojtek/magicoder:6.7b-s-ds-q8_0))_
+-   CodeQwen1.5 _(tested with [codeqwen:7b-code-v1.5-q5_1](https://ollama.com/library/codeqwen:7b-code-v1.5-q5_1))_
 
 Supported Models for _Chat_:
 
@@ -71,7 +72,7 @@ Supported Models for _Chat_:
 -   Phind-CodeLlama - _(tested with: [phind-codellama:34b-v2-q2_K](https://ollama.ai/library/phind-codellama:34b-v2-q2_K))_
 -   Magicoder-DS _(tested with [wojtek/magicoder:6.7b-s-ds-q8_0](https://ollama.com/wojtek/magicoder:6.7b-s-ds-q8_0))_
 -   Llama3-Instruct _(tested with [llama3:8b-instruct-q6_K](https://ollama.com/library/llama3:8b-instruct-q6_K))_
-
+-   CodeQwen1.5-Code _(tested with [codeqwen:7b-chat-v1.5-q8_0](https://ollama.com/library/codeqwen:7b-code-v1.5-q8_0))_
 ---
 
 ### Hugging Face

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "wing-man",
 	"displayName": "Wingman-AI",
 	"description": "Wingman - AI powered assistant to help you write your best code, we won't leave you hanging.",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"publisher": "WingMan",
 	"license": "MIT",
 	"authors": [

--- a/src/webview-ui/utilities/localMemState.ts
+++ b/src/webview-ui/utilities/localMemState.ts
@@ -1,11 +1,13 @@
 class LocalMemState {
   state: Record<string, unknown> = {};
+  savedState = this.state;
   listeners: Set<() => void> = new Set();
 
   getState = (key: string) => this.state[key];
 
   setState = (key: string, payload: unknown) => {
     this.state[key] = payload;
+    this.savedState = { ...this.state };
     this.listeners.forEach(l => l());
   };
 
@@ -17,7 +19,7 @@ class LocalMemState {
   };
 
   getSnapshot = () => {
-    return { ...this.state };
+    return this.savedState;
   };
 }
 

--- a/src/webview-ui/utilities/logger.ts
+++ b/src/webview-ui/utilities/logger.ts
@@ -1,0 +1,8 @@
+import { vscode } from './vscode';
+
+export const logger = (msg: string) => {
+  vscode.postMessage({
+    command: 'log',
+    value: { msg }
+  });
+}


### PR DESCRIPTION
The chat keeps re-rendering because getSnapshot is always returning a new object and it causes the chat to crash